### PR TITLE
feat: use SQLite VSS for RAG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "@llamaindex/ollama": "^0.1.20",
         "@llamaindex/workflow": "^1.1.20",
         "llamaindex": "^0.11.26",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "better-sqlite3": "^9.4.0",
+        "sqlite-vss": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^24.2.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@llamaindex/ollama": "^0.1.20",
     "@llamaindex/workflow": "^1.1.20",
     "llamaindex": "^0.11.26",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "better-sqlite3": "^9.4.0",
+    "sqlite-vss": "^0.1.0"
   }
 }

--- a/src/tools/rag.tools.ts
+++ b/src/tools/rag.tools.ts
@@ -1,9 +1,11 @@
-import { VectorStoreIndex, tool, Settings, Document } from 'llamaindex';
+import { tool, Settings } from 'llamaindex';
 import { z } from 'zod';
 import { HuggingFaceEmbedding } from '@llamaindex/huggingface';
 import { Ollama } from '@llamaindex/ollama';
 import * as fs from 'fs';
 import * as path from 'path';
+import Database from 'better-sqlite3';
+import sqliteVss from 'sqlite-vss';
 
 // Configure embedding and LLM models
 Settings.embedModel = new HuggingFaceEmbedding();
@@ -14,32 +16,47 @@ Settings.llm = new Ollama({
   }
 });
 
-async function getDataSource() {
-  const allDocuments: Document[] = [];
-  
-  // Load markdown documents
-  const docsDir = 'docs';
-  const markdownFiles = fs.readdirSync(docsDir).filter(file => file.endsWith('.md'));
-  
-  for (const mdFile of markdownFiles) {
-    const filePath = path.join(docsDir, mdFile);
-    const content = fs.readFileSync(filePath, 'utf-8');
-    const document = new Document({
-      text: content,
-      metadata: {
-        file_name: mdFile,
-        file_path: filePath,
-        file_type: 'markdown'
-      }
-    });
+let db: Database.Database | null = null;
 
-    allDocuments.push(document);
+function float32ArrayToBuffer(arr: number[]): Buffer {
+  return Buffer.from(new Float32Array(arr).buffer);
+}
+
+async function initializeDatabase(): Promise<Database.Database> {
+  if (db) return db;
+
+  const dbPath = path.join('docs.db');
+  db = new Database(dbPath);
+  db.loadExtension(sqliteVss.vss_loadable_path);
+
+  db.exec(`CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY,
+    content TEXT
+  );`);
+
+  // Determine embedding dimension from a sample embedding
+  const sampleEmbedding = await Settings.embedModel.getTextEmbedding('dimension check');
+  const dimension = sampleEmbedding.length;
+  db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS doc_embeddings USING vss0(embedding(${dimension}));`);
+
+  // Load markdown documents if not already present
+  const count = db.prepare('SELECT COUNT(*) as c FROM documents').get().c as number;
+  if (count === 0) {
+    const docsDir = 'docs';
+    const markdownFiles = fs.readdirSync(docsDir).filter(file => file.endsWith('.md'));
+    const insertDoc = db.prepare('INSERT INTO documents(content) VALUES(?)');
+    const insertEmb = db.prepare('INSERT INTO doc_embeddings(rowid, embedding) VALUES(?, ?)');
+
+    for (const mdFile of markdownFiles) {
+      const filePath = path.join(docsDir, mdFile);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const info = insertDoc.run(content);
+      const embedding = await Settings.embedModel.getTextEmbedding(content);
+      insertEmb.run(info.lastInsertRowid, float32ArrayToBuffer(embedding));
+    }
   }
-  
-  // Create index from documents (in-memory for simplicity)
-  const index = await VectorStoreIndex.fromDocuments(allDocuments);
-  
-  return index;
+
+  return db;
 }
 
 export const ragTool = tool({
@@ -51,14 +68,18 @@ export const ragTool = tool({
   execute: async ({ query }: { query: string }) => {
     console.log(`RAG Tool SEARCH: Searching for "${query}" in documentation...`);
 
-    const index = await getDataSource();
-    const queryEngine = index.asQueryEngine({
-      similarityTopK: 5 // Return top 5 most relevant chunks
-    });
+    const database = await initializeDatabase();
+    const queryEmbedding = await Settings.embedModel.getTextEmbedding(query);
+    const stmt = database.prepare(`
+      SELECT documents.content, doc_embeddings.distance
+      FROM doc_embeddings JOIN documents ON documents.id = doc_embeddings.rowid
+      WHERE doc_embeddings MATCH vss_search(?, 5)
+      ORDER BY distance
+    `);
 
-    const response = await queryEngine.query({ query });
-    const responseText = response.toString();
-    
-    return responseText;
+    const rows = stmt.all(float32ArrayToBuffer(queryEmbedding));
+    const resultText = rows.map((r: any) => r.content).join('\n---\n');
+
+    return resultText;
   },
 });


### PR DESCRIPTION
## Summary
- add SQLite database with sqlite-vss extension to store document embeddings
- query documentation via vector search for RAG answers
- include better-sqlite3 and sqlite-vss dependencies

## Testing
- ⚠️ `npm test` (missing script: test)
- ⚠️ `npm run build` (sh: 1: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a309bbdd188331ae9e1d41d72f7165